### PR TITLE
Import GPS messages

### DIFF
--- a/recipes-ros/gps_umd/gps-common_0.2.0.bb
+++ b/recipes-ros/gps_umd/gps-common_0.2.0.bb
@@ -1,0 +1,23 @@
+DESCRIPTION = "GPS messages and common routines for use in GPS drivers."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "message-generation \
+    message-filters \
+    nav-msgs \
+    roscpp \
+    rospy \
+    sensor-msgs \
+    std-msgs \
+"
+RDEPENDS_${PN} = "message-filters \
+    message-runtime \
+    nav-msgs \
+    roscpp \
+    rospy \
+    sensor-msgs \
+    std-msgs \
+"
+
+require gps-umd.inc

--- a/recipes-ros/gps_umd/gps-umd.inc
+++ b/recipes-ros/gps_umd/gps-umd.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/swri-robotics/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "003a1699a10b8c177868c3cc28067560"
+SRC_URI[sha256sum] = "de549789304688ca5b93ea0c3a30d45de080fa61d0e2596ae81bb0e7eefd855d"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "gps_umd"


### PR DESCRIPTION
## Description

This imports the gps_common package, which contains messages for GPS sensors. For more information, see:

* http://wiki.ros.org/gps_common

ROS has GPS support built-in, however UMD has extended the base functionality. The goal is to merge UMD's work back into ROS in the future, so for now we import their messages.

## How has this been tested?

I created a dummy GPS ros node that is hard-coded to report the GPS coordinates of Aclima's office. I connected it to the weather info in the Sundstrom HUD, and the HUD successfully shows weather for San Francisco.