### PR TITLE
Fix pycurl build

### DIFF
--- a/recipes-devtools/python/python-pycurl_7.43.0.bb
+++ b/recipes-devtools/python/python-pycurl_7.43.0.bb
@@ -13,4 +13,8 @@ SRC_URI[sha256sum] = "aa975c19b79b6aa6c0518c0cc2ae33528900478f0b500531dbcdbf05be
 
 S = "${WORKDIR}/${SRCNAME}-${PV}"
 
+do_compile_prepend() {
+    make gen
+}
+
 inherit distutils


### PR DESCRIPTION
Error was:

```
arm-sundstrom-linux-gnueabi-gcc: error: src/docstrings.c: No such file or directory
```