### PR TITLE
Python fixes

### DIFF
--- a/recipes-devtools/python/python-catkin-pkg.inc
+++ b/recipes-devtools/python/python-catkin-pkg.inc
@@ -13,7 +13,7 @@ SRC_URI[sha256sum] = "77fdfdcf79b1b92498c83eede9ef727e9c6eeec5b0a5e49c0ce83b8caa
 
 inherit pypi
 
-RDEPENDS_${PN} = "${PYTHON_PN}-unixadmin"
+RDEPENDS_${PN} = "${PYTHON_PN}-catkin-pkg-modules ${PYTHON_PN}-unixadmin"
 RDEPENDS_${PN}_class-native = ""
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python-rosdep_0.11.5.bb
+++ b/recipes-devtools/python/python-rosdep_0.11.5.bb
@@ -1,5 +1,3 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/python-catkin-pkg-modules:"
-
 require python-rosdep.inc
 
 inherit setuptools


### PR DESCRIPTION
## Description

This PR contains fixes for the following Python modules:

* **catkin_pkg** - Fixes missing dependency on catkin_pkg_modules
* **rosdep** - Removes unused/incorrect extra files path

## How has this been tested?

Tested by launching a roslaunch file on build 1.0 alpha 7.